### PR TITLE
PD-6313 re-generate the index.yaml with complete URL

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,11 +3,11 @@ entries:
   helm-namerd:
   - apiVersion: v1
     appVersion: 1.7.0
-    created: "2020-04-22T15:41:17.778-04:00"
+    created: "2020-04-22T16:22:25.925898-04:00"
     description: Service that manages routing for multiple linkerd instances
     digest: afe47ee22285078185f9f0087f108d818d72a790196f4dddfa8cbb363e651469
     name: helm-namerd
     urls:
-    - helm-namerd-0.1.0.tgz
+    - https://applauseoss.github.io/helm-namerd/helm-namerd-0.1.0.tgz
     version: 0.1.0
-generated: "2020-04-22T15:41:17.77304-04:00"
+generated: "2020-04-22T16:22:25.916458-04:00"


### PR DESCRIPTION
I should have run this initially,
`helm repo add --url https://applauseoss.github.io/helm-namerd/ .`
This will generate the index.yaml with the complete URL and is suggested in the best practices